### PR TITLE
DFU timeout prevention

### DIFF
--- a/python-file-downloader/application/src/dfu.py
+++ b/python-file-downloader/application/src/dfu.py
@@ -1,7 +1,6 @@
 from time import time, sleep
 import binascii
 import hashlib
-from contextlib import contextmanager
 
 class dfuReader:
     OpenTimeoutSec = 120
@@ -192,15 +191,24 @@ def setVersion(card, version):
     _cardTransactionFailsOnNotecardErrorMessage(card,
                     {"req":"dfu.status","version":version})
 
-@contextmanager
+
+class _dfuReader_ContextManager(object):
+    def __init__(self, reader):
+        self.reader = reader
+    
+    def __enter__(self):
+        self.reader.Open()
+        return self.reader
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.reader.Close()
+
 def openDfuForRead(card, reader=None):
     if reader==None:
         reader = dfuReader(card)
-    reader.Open()
-    try:
-        yield reader
-    finally:
-        reader.Close()
+    
+    return _dfuReader_ContextManager(reader)
+
 
 def copyImageToWriter(card, writer, size=4096, reader=None,progressUpdater=lambda m:None):
 

--- a/python-file-downloader/application/src/dfu.py
+++ b/python-file-downloader/application/src/dfu.py
@@ -1,5 +1,5 @@
 from time import time, sleep
-import base64
+import binascii
 import hashlib
 from contextlib import contextmanager
 
@@ -129,7 +129,7 @@ class dfuReader:
         if "payload" not in rsp:
             raise Exception(f"No content available at {start} with length {length}")
 
-        content = base64.b64decode(rsp["payload"])
+        content = binascii.a2b_base64(rsp["payload"])
 
         expectedMD5 = rsp["status"]
         md5 = hashlib.md5(content).hexdigest()


### PR DESCRIPTION
Adds feature to perform
```
{"req":"hub.set","mode":"dfu"}
```

while reading DFU data from Notecard.

This DFU Mode Reset is configured to happen by default every 240 sec (4 minutes) while reading.  It can be configured by setting the `DFUModeResetPeriodSec` parameter of the dfuReader object