### PR TITLE
Patch setting product_uid issue

### DIFF
--- a/python-large-file-upload/main.py
+++ b/python-large-file-upload/main.py
@@ -48,7 +48,7 @@ def parseCommandLineArgs():
         hub_config['sync'] = True
 
     if opts.product_uid:
-        hub_config['product'] = opts
+        hub_config['product'] = opts.product_uid
 
     opts.hub_config = None if hub_config=={} else hub_config
 


### PR DESCRIPTION
When using the command line arguments for the Notecard product UID, it failed because the entire `opt` data structure was passed as the value to the product UID instead of the product UID field.