### PR TITLE
large-file-upload: always print elapsed time when -e arg is passed

### DIFF
--- a/python-large-file-upload/main.py
+++ b/python-large-file-upload/main.py
@@ -134,7 +134,10 @@ def main():
 
 
     if opts.measure_elapsed_time:
-        logging.info(f"Sent file: {opts.file}\n{fileSizeInBytes/1024} KB\n{endTime-startTime} seconds")
+        if opts.debug:
+            logging.info(f"Sent file: {opts.file}\n{fileSizeInBytes/1024} KB\n{endTime-startTime} seconds")
+        else:
+            print(f"Sent file: {opts.file}\n{fileSizeInBytes/1024} KB\n{endTime-startTime} seconds")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Prior to this change, the elapsed time would only be printed when the -d (debug) option is passed. This change makes it so that the elapsed time will always be printed regardless of the d option

Tested this by launching application in debug mode and in normal mode and saw the elapsed time in both cases when -e option was passed.