### PR TITLE
large-file-upload: add option to set binary buffer size

### DIFF
--- a/python-large-file-upload/main.py
+++ b/python-large-file-upload/main.py
@@ -41,7 +41,7 @@ def parseCommandLineArgs():
     p.add("-i", "--include-file-name", help="Add file name as query parameter to web request", action='store_true')
     p.add("-e", "--measure-elapsed-time", help="Measure how long the file transfer process takes", action='store_true')
     p.add("--legacy", help="Use legacy method to upload file. Uses base64 encoding in web transaction payloads", action='store_true')
-    
+    p.add("-B", "--binary-size", help="Size of binary data to send in each transaction", type=int)
 
     opts = p.parse_args()
     hub_config = {}
@@ -123,6 +123,9 @@ def main():
     if opts.include_file_name:
         fileName = os.path.basename(os.path.normpath(opts.file))
         uploader.setFileName(fileName)
+
+    if opts.binary_size:
+        uploader.setBinaryBuffSize(opts.binary_size)
 
     startTime = 0
     fileSizeInBytes = 0

--- a/python-large-file-upload/notecardDataTransfer.py
+++ b/python-large-file-upload/notecardDataTransfer.py
@@ -27,7 +27,8 @@ class BinaryDataUploader:
         self.webReqRoot['route'] = route
         self.webReqRoot['seconds'] = timeout
         self._fileName = None
-        
+        self._binaryBuffSize = None
+
     def setFileName(self, fileName):
         self._fileName = fileName
 
@@ -96,8 +97,13 @@ class BinaryDataUploader:
             binary_helpers.binary_store_reset(self._card)
             rsp = self._sendRequest("card.binary")
             max = rsp.get("max", 0)
-            
-            buffer = bytearray(max)
+
+            if self._binaryBuffSize is not None:
+                buffSize = self._binaryBuffSize
+            else:
+                buffSize = max
+
+            buffer = bytearray(buffSize)
             numBytes = data.readinto(buffer)
 
             binary_helpers.binary_store_transmit(self._card, buffer[0:numBytes], 0)
@@ -126,6 +132,9 @@ class BinaryDataUploader:
     def _unsetTempContinuousMode(self):
         req = {"req":"hub.set", "off":True}
         self._sendRequest(req)
+
+    def setBinaryBuffSize(self, binaryBuffSize):
+        self._binaryBuffSize = binaryBuffSize
 
 
 import binascii


### PR DESCRIPTION
The command line argument -B/--binary-size can now be used to set the binary buffer size that will be used when transmitting binary data to Notehub. This gives more control to the user and is beneficial in case there are any application/firmware issues with sending large binary data

Tested by passing -B with different sizes (100000, 150000, 200000). Also tested that without passing the -B argument, the binary "max" will be used (which is ~261kB for NOTE-WBEXW). 