### PR TITLE
large-file-upload: add option to set the HTTP request type

### DIFF
--- a/python-large-file-upload/main.py
+++ b/python-large-file-upload/main.py
@@ -5,7 +5,6 @@ import configargparse
 import time
 import notecardDataTransfer
 import os
-import sys
 
 # Define default options
 DEFAULT_SERIAL_PORT_ID = "COM4"
@@ -42,7 +41,7 @@ def parseCommandLineArgs():
     p.add("-i", "--include-file-name", help="Add file name as query parameter to web request", action='store_true')
     p.add("-e", "--measure-elapsed-time", help="Measure how long the file transfer process takes", action='store_true')
     p.add("--legacy", help="Use legacy method to upload file. Uses base64 encoding in web transaction payloads", action='store_true')
-    p.add("-w", "--web-req-type", help="HTTP request type (PUT, POST, etc)", default="POST")
+    p.add("-w", "--web-req-method", help="HTTP request method (PUT, POST, etc)", default="POST")
 
     opts = p.parse_args()
     hub_config = {}
@@ -113,16 +112,12 @@ def main():
         logging.info(f"HUB config: {opts.hub_config}")
 
 
-    if opts.web_req_type.upper() == "PUT":
+    if opts.web_req_method.upper() == "PUT":
         req = "web.put"
-    elif opts.web_req_type.upper() == "POST":
+    elif opts.web_req_method.upper() == "POST":
         req = "web.post"
     else:
-        if opts.debug:
-            logging.debug(f"Error: Invalid web request type: {opts.web_req_type}, options are 'PUT' or 'POST'")
-        else:
-            print(f"Error: Invalid web request type: {opts.web_req_type}, options are 'PUT' or 'POST'")
-        sys.exit(1)
+        raise(Exception(f"Error: Invalid web request method: {opts.web_req_method}, options are 'PUT' or 'POST'"))
 
     if opts.legacy:
         uploader = notecardDataTransfer.BinaryDataUploaderLegacy(

--- a/python-large-file-upload/main.py
+++ b/python-large-file-upload/main.py
@@ -5,6 +5,7 @@ import configargparse
 import time
 import notecardDataTransfer
 import os
+import sys
 
 # Define default options
 DEFAULT_SERIAL_PORT_ID = "COM4"
@@ -21,7 +22,7 @@ DEFAULT_CONNECTION_TIMEOUT_SECS = 90
 def parseCommandLineArgs():
 
     DESCRIPTION = """Example for uploading larger files and data to the cloud
-    
+
     """
 
 
@@ -41,7 +42,7 @@ def parseCommandLineArgs():
     p.add("-i", "--include-file-name", help="Add file name as query parameter to web request", action='store_true')
     p.add("-e", "--measure-elapsed-time", help="Measure how long the file transfer process takes", action='store_true')
     p.add("--legacy", help="Use legacy method to upload file. Uses base64 encoding in web transaction payloads", action='store_true')
-    
+    p.add("-w", "--web-req-type", help="HTTP request type (PUT, POST, etc)", default="POST")
 
     opts = p.parse_args()
     hub_config = {}
@@ -56,16 +57,12 @@ def parseCommandLineArgs():
 
     return opts
 
-
-
-
 def connectToNotecard(opts):
     ## Connect to Notecard
     port = serial.Serial(opts.port, baudrate=opts.baudrate)
     card = notecard.OpenSerial(port, debug=opts.debug)
 
     return card
-
 
 ## Notecard Request Method
 def sendRequest(card, req, args=None, errRaisesException=True):
@@ -82,7 +79,6 @@ def sendRequest(card, req, args=None, errRaisesException=True):
         raise Exception("Notecard Transaction Error: " + rsp['err'])
 
     return rsp
-
 
 def main():
 
@@ -106,7 +102,7 @@ def main():
     logging.info(opts)
 
     card = connectToNotecard(opts)
-        
+
     ## Log Notecard Info
     rsp = sendRequest(card, "card.version")
     logging.info(f"NOTECARD INFO Device: {rsp['device']} SKU: {rsp['sku']} Firmware Version: {rsp['version']}")
@@ -116,10 +112,35 @@ def main():
         sendRequest(card, "hub.set", opts.hub_config)
         logging.info(f"HUB config: {opts.hub_config}")
 
-    uploader = (notecardDataTransfer.BinaryDataUploaderLegacy(card, opts.route, printFcn=logging.debug, timeout=opts.timeout)
-                if opts.legacy
-                else notecardDataTransfer.BinaryDataUploader(card, opts.route, printFcn=logging.debug, timeout=opts.timeout))
-    
+
+    if opts.web_req_type.upper() == "PUT":
+        req = "web.put"
+    elif opts.web_req_type.upper() == "POST":
+        req = "web.post"
+    else:
+        if opts.debug:
+            logging.debug(f"Error: Invalid web request type: {opts.web_req_type}, options are 'PUT' or 'POST'")
+        else:
+            print(f"Error: Invalid web request type: {opts.web_req_type}, options are 'PUT' or 'POST'")
+        sys.exit(1)
+
+    if opts.legacy:
+        uploader = notecardDataTransfer.BinaryDataUploaderLegacy(
+            card,
+            req,
+            opts.route,
+            printFcn=logging.debug,
+            timeout=opts.timeout,
+            )
+    else:
+        uploader = notecardDataTransfer.BinaryDataUploader(
+            card,
+            req,
+            opts.route,
+            printFcn=logging.debug,
+            timeout=opts.timeout,
+            )
+
     if opts.include_file_name:
         fileName = os.path.basename(os.path.normpath(opts.file))
         uploader.setFileName(fileName)


### PR DESCRIPTION
Prior to this commit, the notecard request method defaulted to "web.post". This commit introduces a new command line option "-w/--web-req-type", allowing users to specify the HTTP request method. This is particularly useful for scenarios such as Azure file transfers where a PUT request is required for Blob transfer APIs.

- Tested that I can successfully transfer files to Microsoft Azure when I pass the "-w put" option.
- Tested that by default the "web.post" option still works when the w option is not passed.
- Tested that existing main example still works.
- Tested that passing an option other than "PUT" or "POST" will result in the application exiting gracefully with the appropriate error message (which is logged if the -d option is passed).