### PR TITLE
large-file-upload: add option to set the HTTP request method

### DIFF
--- a/python-large-file-upload/main.py
+++ b/python-large-file-upload/main.py
@@ -5,7 +5,6 @@ import configargparse
 import time
 import notecardDataTransfer
 import os
-import sys
 
 # Define default options
 DEFAULT_SERIAL_PORT_ID = "COM4"
@@ -43,7 +42,7 @@ def parseCommandLineArgs():
     p.add("-e", "--measure-elapsed-time", help="Measure how long the file transfer process takes", action='store_true')
     p.add("--legacy", help="Use legacy method to upload file. Uses base64 encoding in web transaction payloads", action='store_true')
     p.add("-B", "--binary-size", help="Size of binary data to send in each transaction", type=int)
-    p.add("-w", "--web-req-type", help="HTTP request type (PUT, POST, etc)", default="POST")
+    p.add("-w", "--web-req-method", help="HTTP request method (PUT, POST, etc)", default="POST")
 
     opts = p.parse_args()
     hub_config = {}
@@ -114,16 +113,12 @@ def main():
         logging.info(f"HUB config: {opts.hub_config}")
 
 
-    if opts.web_req_type.upper() == "PUT":
+    if opts.web_req_method.upper() == "PUT":
         req = "web.put"
-    elif opts.web_req_type.upper() == "POST":
+    elif opts.web_req_method.upper() == "POST":
         req = "web.post"
     else:
-        if opts.debug:
-            logging.debug(f"Error: Invalid web request type: {opts.web_req_type}, options are 'PUT' or 'POST'")
-        else:
-            print(f"Error: Invalid web request type: {opts.web_req_type}, options are 'PUT' or 'POST'")
-        sys.exit(1)
+        raise(Exception(f"Error: Invalid web request method: {opts.web_req_method}, options are 'PUT' or 'POST'"))
 
     if opts.legacy:
         uploader = notecardDataTransfer.BinaryDataUploaderLegacy(

--- a/python-large-file-upload/notecardDataTransfer.py
+++ b/python-large-file-upload/notecardDataTransfer.py
@@ -4,11 +4,12 @@ import io
 
 
 DEFAULT_WEB_TRANSACTION_TIMEOUT_SEC = 30
+DEFAULT_CARD_WEB_REQUEST = "web.post"
 
 
 class BinaryDataUploader:
 
-    webReqRoot = {"req":"web.post",
+    webReqRoot = {"req":DEFAULT_CARD_WEB_REQUEST,
                 "seconds": DEFAULT_WEB_TRANSACTION_TIMEOUT_SEC,
                 "content":"application/octet-stream",
                 "binary":True,
@@ -16,14 +17,15 @@ class BinaryDataUploader:
                 "offset":0,
                 "total":0
                 }
-    
+
     ConnectionTimeoutSeconds = 90
 
-    def __init__(self, card, route, timeout=DEFAULT_WEB_TRANSACTION_TIMEOUT_SEC, printFcn=print, waitForNotehubConnection=True, setTempContinuousMode=True) -> None:
+    def __init__(self, card, req, route, timeout=DEFAULT_WEB_TRANSACTION_TIMEOUT_SEC, printFcn=print, waitForNotehubConnection=True, setTempContinuousMode=True) -> None:
         self._card = card
         self._print = printFcn
         self.WaitForConnection = waitForNotehubConnection
         self.SetTemporaryContinuousMode=setTempContinuousMode
+        self.webReqRoot['req'] = req
         self.webReqRoot['route'] = route
         self.webReqRoot['seconds'] = timeout
         self._fileName = None
@@ -38,7 +40,7 @@ class BinaryDataUploader:
     def upload(self, data:io.BytesIO, unsetFileName=True):
         if self.SetTemporaryContinuousMode:
             self._setTempContinuousMode()
-        
+
         if self.WaitForConnection:
             self._print(f"Waiting for Notehub connection")
             self._waitForConnection()
@@ -50,7 +52,7 @@ class BinaryDataUploader:
 
         if unsetFileName:
             self.unsetFileName()
-        
+
     ## Notecard Request Method
     def _sendRequest(self, req, args=None, errRaisesException=True):
         if isinstance(req,str):
@@ -66,14 +68,14 @@ class BinaryDataUploader:
             raise Exception("Notecard Transaction Error: " + rsp['err'])
 
         return rsp
-        
+
     def _writeWebReqBinary(self, offset, total):
         webReq = self.webReqRoot
         webReq['offset'] = offset
         webReq['total'] = total
         if self._fileName is not None:
             webReq['name'] = self._fileName
-        
+
         rsp = self._sendRequest(webReq)
 
         if rsp.get("result", 300) >= 300:
@@ -88,7 +90,7 @@ class BinaryDataUploader:
 
 
     def _writeAndFlushBytes(self, data: io.IOBase):
-        
+
         totalBytes = data.seek(0,2)
         data.seek(0,0)
 
@@ -122,7 +124,7 @@ class BinaryDataUploader:
         while not isConnected:
             if (time.time() - startTime) > self.ConnectionTimeoutSeconds:
                 raise(Exception(f"Timeout of {self.ConnectionTimeoutSeconds} seconds expired while waiting to connect to Notehub"))
-            
+
             rsp = self._sendRequest("hub.status")
             isConnected =  rsp.get('connected', False)
             time.sleep(1)
@@ -142,7 +144,7 @@ class BinaryDataUploader:
 
 import binascii
 class BinaryDataUploaderLegacy(BinaryDataUploader):
-    webReqRoot = {"req":"web.post",
+    webReqRoot = {"req":DEFAULT_CARD_WEB_REQUEST,
                 "seconds": DEFAULT_WEB_TRANSACTION_TIMEOUT_SEC,
                 "payload": '',
                 "route": '',
@@ -153,7 +155,7 @@ class BinaryDataUploaderLegacy(BinaryDataUploader):
     def upload(self, data:io.BytesIO):
         if self.SetTemporaryContinuousMode:
             self._setTempContinuousMode()
-        
+
         if self.WaitForConnection:
             self._print(f"Waiting for Notehub connection")
             self._waitForConnection()


### PR DESCRIPTION
This PR contains code that adds a new command line option -w/--web-req-method, allowing users to specify the HTTP request method. This is particularly useful for scenarios like Azure Blob transfers, which require a PUT request.